### PR TITLE
Change platforms to include previous iOS versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,8 @@ import PackageDescription
 
 let package = Package(
     name: "SFSymbol",
-  platforms: [
-        .macOS(.v10_13), .iOS(.v13), .tvOS(.v13),
+    platforms: [
+        .macOS(.v10_13), .iOS(.v11), .tvOS(.v11),
     ],
     products: [
         .library(


### PR DESCRIPTION
Just a small change. On SPM we cant deploy to <= iOS12. Since all types already have @available we can just change the platforms.