### PR TITLE
Add availability check to UIImage+SFSymbol

### DIFF
--- a/Sources/SFSymbol/UIImage+SFSymbol.swift
+++ b/Sources/SFSymbol/UIImage+SFSymbol.swift
@@ -8,6 +8,7 @@
 #if canImport(UIKit)
 import UIKit
 
+@available(iOS 13.0, *)
 public extension UIImage {
     convenience init?(symbol: SFSymbol) {
         self.init(systemName: symbol.rawValue)


### PR DESCRIPTION
Fixes build errors on iOS 14 with an availability check for iOS 13. 

Please see issue for more information https://github.com/Nirma/SFSymbol/issues/7.