### PR TITLE
Removed convince initializers

### DIFF
--- a/Sources/SFSymbol/UIImage+SFSymbol.swift
+++ b/Sources/SFSymbol/UIImage+SFSymbol.swift
@@ -25,11 +25,11 @@ import UIKit
 
 @available(iOS 13.0, *)
 public extension UIImage {
-    convenience init?(symbol: SFSymbol) {
-        self.init(systemName: symbol.rawValue)
+    convenience init(symbol: SFSymbol) {
+        self.init(systemName: symbol.rawValue)!
     }
-    convenience init?(symbol: SFSymbol, with configuration: Configuration) {
-        self.init(systemName: symbol.rawValue, withConfiguration: configuration)
+    convenience init(symbol: SFSymbol, with configuration: Configuration) {
+        self.init(systemName: symbol.rawValue, withConfiguration: configuration)!
     }
 }
 

--- a/Sources/SFSymbol/UIImage+SFSymbol2.swift
+++ b/Sources/SFSymbol/UIImage+SFSymbol2.swift
@@ -25,11 +25,11 @@ import UIKit
 
 @available(iOS 14.0, *)
 public extension UIImage {
-    convenience init?(symbol: SFSymbol2) {
-        self.init(systemName: symbol.rawValue)
+    convenience init(symbol: SFSymbol2) {
+        self.init(systemName: symbol.rawValue)!
     }
-    convenience init?(symbol: SFSymbol2, with configuration: Configuration) {
-        self.init(systemName: symbol.rawValue, withConfiguration: configuration)
+    convenience init(symbol: SFSymbol2, with configuration: Configuration) {
+        self.init(systemName: symbol.rawValue, withConfiguration: configuration)!
     }
 }
 

--- a/Tests/SFSymbolTests/SFSymbolTests.swift
+++ b/Tests/SFSymbolTests/SFSymbolTests.swift
@@ -17,9 +17,4 @@ class SFSymbolTests: XCTestCase {
             XCTAssert(image != nil, "\(symbol.rawValue) does not exist!")
         }
     }
-
-    func testConvenienceInitilizer() {
-        let image = UIImage(symbol: .airplane)
-        XCTAssert(image != nil, "UIImage(symbol:) initializer is broken.")
-    }
 }


### PR DESCRIPTION
Since this is a first party image solution by Apple, there is no need to have it use convince initializers. Additionally, because there is a test case for all symbols we know they all work.