### PR TITLE
Fix compiler error when linking against watchOS target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "SFSymbol",
     platforms: [
-        .macOS(.v10_13), .iOS(.v13), .tvOS(.v13)
+        .macOS(.v10_13), .iOS(.v13), .tvOS(.v13), .watchOS(.v6)
     ],
     products: [
         .library(


### PR DESCRIPTION
Sets watchOS platform version to at least watchOS 6, such that it can be linked against watchOS targets.

Previously, as there was no minimum SDK specified, it would attempt to compile and link against all watchOS SDKs. As SFSymbol initialisers for Image and UIImage were introduced in watchOS 6, the package would fail to compile and link against watchOS targets.

This is akin to PRs created by other contributors for patching compiler errors for iOS and tvOS.