### PR TITLE
macOS 11 @available for initializers

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Sources/SFSymbol/Image+SFSymbol.swift
+++ b/Sources/SFSymbol/Image+SFSymbol.swift
@@ -22,6 +22,7 @@
 
 import SwiftUI
 
+@available(macOS 11, *)
 @available(iOS 13, *)
 public extension Image {
     /// Create Image from SFSymbol

--- a/Sources/SFSymbol/Image+SFSymbol2.swift
+++ b/Sources/SFSymbol/Image+SFSymbol2.swift
@@ -22,6 +22,7 @@
 
 import SwiftUI
 
+@available(macOS 11.0, *)
 @available(iOS 14.0, *)
 public extension Image {
     /// Create Image from SFSymbol2

--- a/Sources/SFSymbol/NSImage+SFSymbol.swift
+++ b/Sources/SFSymbol/NSImage+SFSymbol.swift
@@ -1,0 +1,36 @@
+//
+//  NSImage+SFSymbol.swift
+//  SFSymbol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#if canImport(Cocoa)
+import Cocoa
+
+@available(macOS 11, *)
+public extension NSImage {
+    convenience init?(symbol: SFSymbol, accessibilityDescription description: String? = nil) {
+        self.init(systemSymbolName: symbol.rawValue, accessibilityDescription: description)
+    }
+    convenience init?(symbol: SFSymbol2, accessibilityDescription description: String? = nil) {
+        self.init(systemSymbolName: symbol.rawValue, accessibilityDescription: description)
+    }
+}
+
+#endif

--- a/Tests/SFSymbolTests/ImageExtensionTests.swift
+++ b/Tests/SFSymbolTests/ImageExtensionTests.swift
@@ -9,6 +9,7 @@ import XCTest
 import SwiftUI
 @testable import SFSymbol
 
+@available(macOS 11, *)
 class ImageExtensionTests: XCTestCase {
     func testImagefromSFSymbol() {
         let imageFromSFSymbol = Image(symbol: .aSquare)

--- a/Tests/SFSymbolTests/SFSymbolTests.swift
+++ b/Tests/SFSymbolTests/SFSymbolTests.swift
@@ -7,19 +7,38 @@
 //
 
 import XCTest
+#if canImport(UIKit)
 import UIKit
+#elseif canImport(Cocoa)
+import Cocoa
+#endif
+
 @testable import SFSymbol
 
 class SFSymbolTests: XCTestCase {
     func testAllSymbolsExist() {
         for symbol in SFSymbol.allCases {
+            #if os(iOS)
             let image = UIImage(systemName: symbol.rawValue)
             XCTAssert(image != nil, "\(symbol.rawValue) does not exist!")
+            #elseif os(macOS)
+            if #available(macOS 11, *) {
+                let image = NSImage(systemSymbolName: symbol.rawValue, accessibilityDescription: nil)
+                XCTAssert(image != nil, "\(symbol.rawValue) does not exist!")
+            }
+            #endif
         }
     }
 
-    func testConvenienceInitilizer() {
+    func testConvenienceInitializer() {
+        #if os(iOS)
         let image = UIImage(symbol: .airplane)
         XCTAssert(image != nil, "UIImage(symbol:) initializer is broken.")
+        #elseif os(macOS)
+        if #available(macOS 11, *) {
+            let image = NSImage(symbol: .airplane)
+            XCTAssert(image != nil, "NSImage(symbol:) initializer is broken.")
+        }
+        #endif
     }
 }


### PR DESCRIPTION
SF Symbols can only be used for macOS 11 and up, as 10.15 lacked the initializer.

This pull request adds necessary tags to ensure that things only work for 11 and up.

I have also added NSImage convenience initialisers, as well as tests for macOS.